### PR TITLE
snap: drop GCONV_PATH, provided by the base snap now

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,2 @@
+To report a security issue, file a [Private Security Report](https://github.com/canonical/mir/security/advisories/new) with a description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy) contains more information about what you can expect when you contact us and what we expect from you.

--- a/scripts/bin/graphics-core22-provider-wrapper.in
+++ b/scripts/bin/graphics-core22-provider-wrapper.in
@@ -4,10 +4,6 @@ set -euo pipefail
 SELF="$( cd -- "$(dirname "$0")/.." ; pwd -P )/usr"
 ARCH_TRIPLETS=( @ARCH_TRIPLETS@ )
 
-if [ "$SNAP_ARCH" == "amd64" ]; then
-  GCONV_PATH=${GCONV_PATH:+$GCONV_PATH:}${SELF}/lib/i386-linux-gnu/gconv
-fi
-
 # VDPAU_DRIVER_PATH only supports a single path, rely on LD_LIBRARY_PATH instead
 for arch in ${ARCH_TRIPLETS[@]}; do
   LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${SELF}/lib/${arch}:${SELF}/lib/${arch}/vdpau
@@ -54,6 +50,5 @@ export __EGL_VENDOR_LIBRARY_DIRS
 export __EGL_EXTERNAL_PLATFORM_CONFIG_DIRS
 export VK_LAYER_PATH
 export XDG_DATA_DIRS
-[ -z ${GCONV_PATH+x} ] || export GCONV_PATH
 
 exec "$@"


### PR DESCRIPTION
The base snap provides gconv for i386 as well now:

```
$ ls -1d /snap/core22/current/usr/lib/*/gconv
/snap/core22/current/usr/lib/i386-linux-gnu/gconv
/snap/core22/current/usr/lib/x86_64-linux-gnu/gconv
```